### PR TITLE
test-suite: fix table output

### DIFF
--- a/git-test
+++ b/git-test
@@ -260,9 +260,9 @@ run_tests() {
     ver="$(git rev-parse --short "$verification")"
 
     if [ -n "$verbose" ]; then
-	gettext -- "iter | commit  | tree    | result"
+	gettext "iter | commit  | tree    | result"
 	echo
-	gettext -- "-----|---------|---------|--------------"
+	gettext "-----|---------|---------|--------------"
 	echo
     fi
 


### PR DESCRIPTION
Fixes a regression introduced by spotify/git-test@b5c08b45

gettext -- "foo ..." seems to return only "--" not "foo ..." causing two
of the tests in test.sh to fail.

Closes https://github.com/spotify/git-test/issues/10.