### PR TITLE
Fix #10: gettext compatibility issue

### DIFF
--- a/git-test
+++ b/git-test
@@ -260,9 +260,9 @@ run_tests() {
     ver="$(git rev-parse --short "$verification")"
 
     if [ -n "$verbose" ]; then
-	gettext -- "iter | commit  | tree    | result"
+	gettext "iter | commit  | tree    | result"
 	echo
-	gettext -- "-----|---------|---------|--------------"
+	gettext " ----|---------|---------|--------------"
 	echo
     fi
 


### PR DESCRIPTION
This is bit ugly, but let's hope that's only cosmetic.

(The right(tm) thing to do is to not have this problem in the first place by not trying to do this as a shell script.)

@ilovezfs: If this doesn't work for you, let me know.